### PR TITLE
QuickEdit.js: Make wikipage.content hook asynchronous

### DIFF
--- a/src/QuickEdit.js
+++ b/src/QuickEdit.js
@@ -482,7 +482,9 @@
 
 		body.on('click', clickHandler);
 		addLinksToChildren(body);
-		mw.hook('wikipage.content').add(addLinksToChildren);
+		mw.hook('wikipage.content').add(function (element) {
+			setTimeout(addLinksToChildren.bind(this, element));
+		});
 	});
 
 	mw.loader.addStyleTag(


### PR DESCRIPTION
This PR modifies the function attached to the `wikipage.content` MediaWiki hook to add links asynchronously. This is to ensure compatibility between this script and VisualEditor, which fires hooks whenever wikipage content is loaded.

The hook getting fired (https://w.wiki/6FU9) synchronously comes before "edit section" links found through a vague JQuery selector search are modified by VisualEditor (https://w.wiki/6FUA), which means QuickEdit would have appended its links before the links get modified by VE. The way VE modifies links (https://w.wiki/6FUC) causes an error, since it attempts to modify an anchor's `href` attribute even if such attribute does not exist, likely because it assumes that there is no other edit link in that element than the one provided by MediaWiki. By wrapping `addLinksToChildren` in a `setTimeout` call, it will instead by run on the next JavaScript "tick", asynchronously from the rest of the operations performed by VisualEditor. On the surface, this is unnoticeable for the user, and shouldn't cause any flashes of content.