### PR TITLE
Fix portlet link typo in CitationStyleMarker.js

### DIFF
--- a/src/CitationStyleMarker.js
+++ b/src/CitationStyleMarker.js
@@ -27,7 +27,7 @@ $(function() {
 			var enabled = document.body.classList.contains('nocsmarker');
 			e.preventDefault();
 			document.body.classList[enabled ? 'remove' : 'add']('nocsmarker');
-			portlet.innerText = enabled ? 'Hide CS maker' : 'Show CS marker';
+			portlet.innerText = enabled ? 'Hide CS marker' : 'Show CS marker';
 		});
 
 		if (window.CSMarkerMode == 'disabled' || window.CSMarkerMode == 'both' && typeCount < 2) {


### PR DESCRIPTION
Hey! I recently installed your CitationStyleMarker script and noticed a minor typo; figured it'd be easiest to just send you a PR.

```diff
- Hide CS maker
+ Hide CS marker
```

All the best! ([User:Bsoyka](https://en.wikipedia.org/wiki/User:Bsoyka))